### PR TITLE
Update dhcpd-options.c

### DIFF
--- a/src/dhcpd-options.c
+++ b/src/dhcpd-options.c
@@ -30,7 +30,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  *
- * changed by Michael Bülte, D-75223 Niefern-Öschelbronn, michael.buelte@bridacom.de (MTA-Support)
+ * changed by Michael BÃ¼lte, D-75223 Niefern-Ã–schelbronn, michael.buelte@bridacom.de (MTA-Support)
  */
  
 #ifdef HAVE_CONFIG_H
@@ -110,7 +110,7 @@ void DecodeOptions( dhcp_message *message ) {
 		//fprintf(stderr,"DEBUG: OPTION: %d LENGTH: %d\n", kT, kL);
 		switch( kT ) {
 		case 0x00:
-			ino++;
+			ino--; // for packets with Padding - Option (0) that has no length (KL) we need to decrement ino
 			//flag = 0;
 			break;
 


### PR DESCRIPTION
Correcting an error for full read of DHCP Options in packets that use Padding - Option (0).
From RFC - Pad Field (Tag: 0, Data: None)
Since this Option has no length, we need to decrement ino for the next loop to have correct next option (kT) to work on in subsequent loop. This fixes problems any modems that use padding in DHCP Options for their DHCP packets.
With old code this would make dhcp server ignore other Options that follow Pad.